### PR TITLE
ci(semantic-release): Corrections

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -47,6 +47,7 @@ jobs:
       - run: ./setup-gpg.sh
         env:
           GPG_KEY: ${{ secrets.SEMREL_GPG_SIGNKEY }}
+          GPG_TTY: $(tty)
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/setup-gpg.sh
+++ b/setup-gpg.sh
@@ -7,8 +7,11 @@ echo "Debugging: Start -> ${GPG_KEY:0:30} ... End -> ${GPG_KEY: -30}"
 
 echo "Importing GPG key..."
 
-# Import the GPG key
-echo "$GPG_KEY" | gpg --batch --import
+# Set the GPG_TTY variable
+export GPG_TTY=$(tty)
+
+# Import the GPG key and set pinentry mode to loopback
+echo "$GPG_KEY" | gpg --batch --pinentry-mode loopback --import
 
 # Add loopback pinentry configuration
 echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf


### PR DESCRIPTION
Setted the GPG_TTY variable and specified that GPG should use a loopback pinentry mode at the time of import itself.