### PR TITLE
ci(semantic-release): Corrections

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -48,6 +48,7 @@ jobs:
         env:
           GPG_KEY: ${{ secrets.SEMREL_GPG_SIGNKEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+          GPG_TTY: $(tty)
       - run: npx semantic-release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/setup-gpg.sh
+++ b/setup-gpg.sh
@@ -5,6 +5,9 @@ set -e
 # Debugging: Show the first and last 30 characters of the GPG key
 echo "Debugging: Start -> ${GPG_KEY:0:30} ... End -> ${GPG_KEY: -30}"
 
+# Assume that the terminal is always a TTY
+export GPG_TTY=$(tty)
+
 # Import the GPG key and set pinentry mode to loopback
 echo "$GPG_KEY" | gpg --batch --pinentry-mode loopback --passphrase "$GPG_PASSPHRASE" --import
 
@@ -15,3 +18,6 @@ gpgconf --reload gpg-agent
 # Configure Git to use the GPG key
 git config --global user.signingkey "$(gpg --list-secret-keys --keyid-format LONG --with-colons | grep sec | awk -F: '{print $5}')"
 git config --global commit.gpgsign true
+
+# Trick to make GPG work
+export GPG_TTY=$(tty)


### PR DESCRIPTION
Telling GPG to assume that the terminal is always a TTY